### PR TITLE
Improve keyboard UI

### DIFF
--- a/Clips Keyboard/Base.lproj/ClipsKeyboardView.xib
+++ b/Clips Keyboard/Base.lproj/ClipsKeyboardView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -80,7 +80,7 @@
                     </constraints>
                 </view>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bas-aS-K5R" customClass="KeyboardButton" customModule="Copy_Better_Keyboard" customModuleProvider="target">
-                    <rect key="frame" x="84" y="228" width="44" height="44"/>
+                    <rect key="frame" x="8" y="228" width="44" height="44"/>
                     <color key="backgroundColor" name="Key"/>
                     <constraints>
                         <constraint firstAttribute="width" secondItem="bas-aS-K5R" secondAttribute="height" multiplier="1:1" id="vl5-8T-suk"/>
@@ -100,7 +100,7 @@
                     </userDefinedRuntimeAttributes>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ec3-KT-jiv" customClass="KeyboardButton" customModule="Copy_Better_Keyboard" customModuleProvider="target">
-                    <rect key="frame" x="134" y="228" width="113" height="44"/>
+                    <rect key="frame" x="58" y="228" width="189" height="44"/>
                     <color key="backgroundColor" name="Key White"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="44" id="wv5-xq-RbZ"/>
@@ -146,42 +146,13 @@
                         <action selector="backspaceUp:" destination="iN0-l3-epB" eventType="touchUpOutside" id="lMw-hQ-8iQ"/>
                     </connections>
                 </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pHs-tw-hN9" customClass="KeyboardButton" customModule="Copy_Better_Keyboard" customModuleProvider="target">
-                    <rect key="frame" x="6" y="228" width="33" height="44"/>
-                    <color key="backgroundColor" name="Key"/>
-                    <constraints>
-                        <constraint firstAttribute="width" secondItem="pHs-tw-hN9" secondAttribute="height" multiplier="3:4" id="yBQ-ap-H4P"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="21"/>
-                    <color key="tintColor" systemColor="labelColor"/>
-                    <state key="normal" image="arrow.left" catalog="system">
-                        <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="large"/>
-                    </state>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="boolean" keyPath="isControlKey" value="YES"/>
-                        <userDefinedRuntimeAttribute type="color" keyPath="defaultBackgroundColor">
-                            <color key="value" name="Key"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="color" keyPath="highlightedBackgroundColor">
-                            <color key="value" name="Key White"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
-                    <connections>
-                        <action selector="scrollToPreviousColumn:" destination="iN0-l3-epB" eventType="touchUpInside" id="Epr-dd-0M4"/>
-                    </connections>
-                </button>
-                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="8z4-Li-KCR">
+                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="8z4-Li-KCR">
                     <rect key="frame" x="0.0" y="48" width="375" height="174"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <constraints>
                         <constraint firstAttribute="height" priority="750" constant="220" id="Q3I-Np-XWd"/>
                     </constraints>
-                    <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="K6Q-aB-L1E">
-                        <size key="itemSize" width="375" height="44"/>
-                        <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                        <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                        <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                    </collectionViewFlowLayout>
+                    <collectionViewLayout key="collectionViewLayout" id="Tfb-6K-vjG"/>
                     <connections>
                         <outlet property="dataSource" destination="iN0-l3-epB" id="neV-MQ-xXy"/>
                         <outlet property="delegate" destination="iN0-l3-epB" id="H2D-cN-b17"/>
@@ -213,30 +184,6 @@
                         <action selector="returnPressed" destination="iN0-l3-epB" eventType="touchUpInside" id="98N-Xd-2wr"/>
                     </connections>
                 </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o3J-Q6-hpE" customClass="KeyboardButton" customModule="Copy_Better_Keyboard" customModuleProvider="target">
-                    <rect key="frame" x="45" y="228" width="33" height="44"/>
-                    <color key="backgroundColor" name="Key"/>
-                    <constraints>
-                        <constraint firstAttribute="width" secondItem="o3J-Q6-hpE" secondAttribute="height" multiplier="3:4" id="qdt-Pi-WVL"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="21"/>
-                    <color key="tintColor" systemColor="labelColor"/>
-                    <state key="normal" image="arrow.right" catalog="system">
-                        <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="large"/>
-                    </state>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="boolean" keyPath="isControlKey" value="YES"/>
-                        <userDefinedRuntimeAttribute type="color" keyPath="defaultBackgroundColor">
-                            <color key="value" name="Key"/>
-                        </userDefinedRuntimeAttribute>
-                        <userDefinedRuntimeAttribute type="color" keyPath="highlightedBackgroundColor">
-                            <color key="value" name="Key White"/>
-                        </userDefinedRuntimeAttribute>
-                    </userDefinedRuntimeAttributes>
-                    <connections>
-                        <action selector="scrollToNextColumn:" destination="iN0-l3-epB" eventType="touchUpInside" id="e63-5N-NLT"/>
-                    </connections>
-                </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <constraints>
@@ -245,29 +192,23 @@
                 <constraint firstItem="75w-yv-2I7" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="75k-0P-jhO"/>
                 <constraint firstItem="aeo-Xp-SNY" firstAttribute="height" secondItem="Ec3-KT-jiv" secondAttribute="height" id="8u4-vN-FJM"/>
                 <constraint firstItem="Ec3-KT-jiv" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" constant="-6" id="8xJ-3X-tqC"/>
-                <constraint firstItem="o3J-Q6-hpE" firstAttribute="leading" secondItem="pHs-tw-hN9" secondAttribute="trailing" constant="6" id="8zS-Uf-IZi"/>
                 <constraint firstItem="75w-yv-2I7" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="CUB-AC-AUc"/>
                 <constraint firstItem="Exl-xm-tBI" firstAttribute="top" secondItem="75w-yv-2I7" secondAttribute="bottom" constant="30" id="Ce1-4Q-o8q"/>
                 <constraint firstItem="bas-aS-K5R" firstAttribute="top" secondItem="Exl-xm-tBI" secondAttribute="bottom" constant="30" id="DB7-Ex-Wzb"/>
                 <constraint firstItem="PEM-Zt-yuJ" firstAttribute="height" secondItem="Ec3-KT-jiv" secondAttribute="height" id="DEv-nE-F6x"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="8z4-Li-KCR" secondAttribute="trailing" id="HUe-sl-tfx"/>
-                <constraint firstItem="Ec3-KT-jiv" firstAttribute="leading" secondItem="o3J-Q6-hpE" secondAttribute="trailing" priority="250" constant="6" id="IsK-NF-Xjb"/>
                 <constraint firstItem="PEM-Zt-yuJ" firstAttribute="leading" secondItem="aeo-Xp-SNY" secondAttribute="trailing" constant="6" id="Jqh-65-Ath"/>
                 <constraint firstItem="aeo-Xp-SNY" firstAttribute="leading" secondItem="Ec3-KT-jiv" secondAttribute="trailing" constant="6" id="KEt-or-1RE"/>
                 <constraint firstItem="Ec3-KT-jiv" firstAttribute="bottom" secondItem="bas-aS-K5R" secondAttribute="bottom" id="LCh-xI-f29"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="PEM-Zt-yuJ" secondAttribute="trailing" constant="6" id="LKg-vB-PcM"/>
-                <constraint firstItem="pHs-tw-hN9" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="6" id="NAb-dR-8ut"/>
                 <constraint firstItem="75w-yv-2I7" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="PQF-Ak-6yc"/>
-                <constraint firstItem="o3J-Q6-hpE" firstAttribute="height" secondItem="Ec3-KT-jiv" secondAttribute="height" id="QFh-vD-kfL"/>
-                <constraint firstItem="o3J-Q6-hpE" firstAttribute="bottom" secondItem="Ec3-KT-jiv" secondAttribute="bottom" id="X3d-KS-pqy"/>
-                <constraint firstItem="Ec3-KT-jiv" firstAttribute="bottom" secondItem="pHs-tw-hN9" secondAttribute="bottom" id="a50-Wj-2Kc"/>
-                <constraint firstItem="Ec3-KT-jiv" firstAttribute="height" secondItem="pHs-tw-hN9" secondAttribute="height" id="aJs-ti-VcT"/>
+                <constraint firstItem="bas-aS-K5R" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="8" id="WbZ-oC-vyM"/>
                 <constraint firstItem="8z4-Li-KCR" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="aWi-Bb-mDE"/>
                 <constraint firstItem="PEM-Zt-yuJ" firstAttribute="bottom" secondItem="Ec3-KT-jiv" secondAttribute="bottom" id="cFH-FS-xbo"/>
                 <constraint firstItem="Ec3-KT-jiv" firstAttribute="height" secondItem="bas-aS-K5R" secondAttribute="height" id="peX-f6-rq2"/>
                 <constraint firstItem="aeo-Xp-SNY" firstAttribute="bottom" secondItem="Ec3-KT-jiv" secondAttribute="bottom" id="qeC-TC-Rm4"/>
+                <constraint firstItem="Ec3-KT-jiv" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" priority="250" constant="6" id="tN6-Fq-DTV"/>
                 <constraint firstItem="Ec3-KT-jiv" firstAttribute="top" secondItem="8z4-Li-KCR" secondAttribute="bottom" constant="6" id="tNu-xf-Toh"/>
-                <constraint firstItem="bas-aS-K5R" firstAttribute="leading" secondItem="o3J-Q6-hpE" secondAttribute="trailing" constant="6" id="wu2-EZ-AlF"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="Exl-xm-tBI" secondAttribute="trailing" constant="30" id="yia-mj-0Kn"/>
                 <constraint firstItem="Exl-xm-tBI" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="30" id="zhH-vK-Qg5"/>
             </constraints>
@@ -275,23 +216,18 @@
             <connections>
                 <outlet property="backspaceKey" destination="aeo-Xp-SNY" id="iUg-Ah-L60"/>
                 <outlet property="collectionView" destination="8z4-Li-KCR" id="JJE-E7-XFw"/>
-                <outlet property="collectionViewLayout" destination="K6Q-aB-L1E" id="oSO-H2-MyR"/>
                 <outlet property="lastCopiedLabel" destination="hg9-Pr-SgV" id="DWx-nA-bPb"/>
                 <outlet property="messageLabel" destination="Exl-xm-tBI" id="7Qe-Hu-FyQ"/>
-                <outlet property="nextColumnButton" destination="o3J-Q6-hpE" id="YUM-6X-Rs4"/>
                 <outlet property="nextKeyboardButton" destination="bas-aS-K5R" id="0B3-Ze-oKo"/>
-                <outlet property="previousColumnButton" destination="pHs-tw-hN9" id="egP-d2-tvi"/>
                 <outlet property="returnKey" destination="PEM-Zt-yuJ" id="V34-f4-DiE"/>
                 <outlet property="spaceKey" destination="Ec3-KT-jiv" id="MLB-Li-vCz"/>
-                <outlet property="spaceKeyToNextColumnButtonConstraint" destination="IsK-NF-Xjb" id="O7c-6S-Qfd"/>
+                <outlet property="spaceKeyToLeadingEdgeConstraint" destination="tN6-Fq-DTV" id="zTd-N9-lXq"/>
                 <outlet property="spaceKeyToNextKeyboardButtonConstraint" destination="33e-CL-XeS" id="3MS-6T-GZV"/>
             </connections>
             <point key="canvasLocation" x="40.799999999999997" y="46.776611694152926"/>
         </view>
     </objects>
     <resources>
-        <image name="arrow.left" catalog="system" width="128" height="98"/>
-        <image name="arrow.right" catalog="system" width="128" height="98"/>
         <image name="delete.left" catalog="system" width="128" height="104"/>
         <image name="delete.left.fill" catalog="system" width="128" height="104"/>
         <image name="globe" catalog="system" width="128" height="121"/>

--- a/Clips Keyboard/KeyboardClipCell.xib
+++ b/Clips Keyboard/KeyboardClipCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Clips Keyboard/KeyboardFolderCell.swift
+++ b/Clips Keyboard/KeyboardFolderCell.swift
@@ -15,7 +15,6 @@ enum Format {
 class KeyboardFolderCell: UICollectionViewCell {
     
     @IBOutlet weak var imageView: UIImageView!
-    @IBOutlet weak var imageViewLeading: NSLayoutConstraint!
     @IBOutlet weak var nameLabel: UILabel!
     
     func setName(_ name: String?) {
@@ -25,15 +24,12 @@ class KeyboardFolderCell: UICollectionViewCell {
     func setFormat(_ format: Format) {
         if format == .folder {
             self.imageView.image = UIImage(systemName: "folder.fill")
-            self.imageViewLeading.constant = 16
         }
         else if format == .superfolder {
             self.imageView.image = UIImage(systemName: "arrowshape.turn.up.left.fill")
-            self.imageViewLeading.constant = 8
         }
         else {
             self.imageView.image = UIImage(systemName: "star.square")
-            self.imageViewLeading.constant = 16
         }
     }
     

--- a/Clips Keyboard/KeyboardFolderCell.xib
+++ b/Clips Keyboard/KeyboardFolderCell.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -10,54 +11,56 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="KeyboardFolderCell" id="23n-g1-SKb" customClass="KeyboardFolderCell" customModule="Copy_Better_Keyboard" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+            <rect key="frame" x="0.0" y="0.0" width="88" height="88"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="8jX-ef-sIs">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="88" height="88"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JBP-bJ-jvW">
-                        <rect key="frame" x="16" y="43" width="359" height="1"/>
-                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="1" id="f4D-ef-aM2"/>
-                        </constraints>
-                    </view>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="folder.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="iO2-5M-DYK">
-                        <rect key="frame" x="16" y="8" width="30" height="27.5"/>
-                        <color key="tintColor" systemColor="systemGrayColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <rect key="frame" x="24" y="13" width="40" height="37.5"/>
+                        <color key="tintColor" systemColor="systemGrayColor"/>
                         <constraints>
-                            <constraint firstAttribute="width" constant="30" id="Zyc-VL-Hf2"/>
-                            <constraint firstAttribute="height" constant="30" id="sIy-kh-U5R"/>
+                            <constraint firstAttribute="width" constant="40" id="Zyc-VL-Hf2"/>
+                            <constraint firstAttribute="height" constant="40" id="sIy-kh-U5R"/>
                         </constraints>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Folder" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sQt-EJ-KGo">
-                        <rect key="frame" x="54" y="11.5" width="305" height="21"/>
-                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Folder" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.80000000000000004" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sQt-EJ-KGo">
+                        <rect key="frame" x="8" y="52" width="72" height="18"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S00-ws-KOL">
+                        <rect key="frame" x="0.0" y="12" width="1" height="64"/>
+                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="1" id="Mef-Ki-oRd"/>
+                        </constraints>
+                    </view>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="iO2-5M-DYK" firstAttribute="leading" secondItem="8jX-ef-sIs" secondAttribute="leading" constant="16" id="3b6-W1-UDn"/>
-                    <constraint firstItem="iO2-5M-DYK" firstAttribute="centerY" secondItem="8jX-ef-sIs" secondAttribute="centerY" id="4IN-pE-nvv"/>
-                    <constraint firstAttribute="trailing" secondItem="sQt-EJ-KGo" secondAttribute="trailing" constant="16" id="IbT-Ee-wBG"/>
-                    <constraint firstItem="sQt-EJ-KGo" firstAttribute="leading" secondItem="iO2-5M-DYK" secondAttribute="trailing" constant="8" id="OET-lg-WgM"/>
-                    <constraint firstItem="JBP-bJ-jvW" firstAttribute="leading" secondItem="8jX-ef-sIs" secondAttribute="leading" constant="16" id="Z6x-Ee-28w"/>
-                    <constraint firstItem="sQt-EJ-KGo" firstAttribute="centerY" secondItem="8jX-ef-sIs" secondAttribute="centerY" id="af1-5w-zAc"/>
-                    <constraint firstAttribute="bottom" secondItem="JBP-bJ-jvW" secondAttribute="bottom" id="dts-Ng-B5s"/>
-                    <constraint firstAttribute="trailing" secondItem="JBP-bJ-jvW" secondAttribute="trailing" id="vq5-np-ItR"/>
+                    <constraint firstItem="sQt-EJ-KGo" firstAttribute="leading" secondItem="8jX-ef-sIs" secondAttribute="leading" constant="8" id="EOV-iZ-bh5"/>
+                    <constraint firstItem="iO2-5M-DYK" firstAttribute="centerY" secondItem="8jX-ef-sIs" secondAttribute="centerY" constant="-12" id="UBb-hb-gR7"/>
+                    <constraint firstItem="iO2-5M-DYK" firstAttribute="centerX" secondItem="8jX-ef-sIs" secondAttribute="centerX" id="XQC-h7-K21"/>
+                    <constraint firstItem="sQt-EJ-KGo" firstAttribute="top" secondItem="iO2-5M-DYK" secondAttribute="bottom" id="g64-dS-of1"/>
+                    <constraint firstItem="S00-ws-KOL" firstAttribute="leading" secondItem="8jX-ef-sIs" secondAttribute="leading" id="ohc-sI-wxt"/>
+                    <constraint firstAttribute="trailing" secondItem="sQt-EJ-KGo" secondAttribute="trailing" constant="8" id="sF0-DX-FPg"/>
+                    <constraint firstItem="S00-ws-KOL" firstAttribute="top" secondItem="8jX-ef-sIs" secondAttribute="top" constant="12" id="sMx-C4-AiG"/>
+                    <constraint firstAttribute="bottom" secondItem="S00-ws-KOL" secondAttribute="bottom" constant="12" id="wds-U7-9l8"/>
                 </constraints>
             </collectionViewCellContentView>
             <connections>
                 <outlet property="imageView" destination="iO2-5M-DYK" id="lvE-Vn-smB"/>
-                <outlet property="imageViewLeading" destination="3b6-W1-UDn" id="eqB-iA-rEK"/>
                 <outlet property="nameLabel" destination="sQt-EJ-KGo" id="K0z-rB-V9V"/>
             </connections>
             <point key="canvasLocation" x="-3" y="-94"/>
         </collectionViewCell>
     </objects>
     <resources>
-        <image name="folder.fill" catalog="system" width="128" height="95"/>
+        <image name="folder.fill" catalog="system" width="128" height="97"/>
+        <systemColor name="systemGrayColor">
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>

--- a/Clips Keyboard/KeyboardViewController.swift
+++ b/Clips Keyboard/KeyboardViewController.swift
@@ -130,14 +130,8 @@ class KeyboardViewController: UIInputViewController, ClipsKeyboardViewDelegate {
     }
     
     private func fetchFavorites() -> [Clip] {
-        let request: NSFetchRequest = NSFetchRequest<Clip>(entityName: "Clip")
-        request.predicate = NSPredicate(format: "isFavorite == true")
-        request.sortDescriptors = [NSSortDescriptor(key: "title", ascending: true)]
-        do {
-            return try self.managedObjectContext.fetch(request)
-        }
-        catch let error as NSError {
-            print("Couldn't fetch. \(error), \(error.userInfo)")
+        if let favorites = Clip.getFavorites(context: self.managedObjectContext, limit: nil) {
+            return favorites
         }
         return []
     }

--- a/Clips Share/Base.lproj/ShareConfigureView.xib
+++ b/Clips Share/Base.lproj/ShareConfigureView.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -28,12 +27,12 @@
                     </connections>
                 </textField>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <constraints>
                 <constraint firstItem="5NJ-4W-cqk" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" constant="8" id="FWt-bK-UZU"/>
                 <constraint firstItem="5NJ-4W-cqk" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="8" id="dWf-s0-n8B"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="5NJ-4W-cqk" secondAttribute="trailing" constant="8" id="hFv-2D-uUF"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <point key="canvasLocation" x="138" y="147"/>
         </view>
     </objects>


### PR DESCRIPTION
## Changes

- Use `UICollectionViewCompositionalLayout` for the custom keyboard's collection view
   - Separate folders and clips into their own sections, with the folder section scrolling horizontally and the rest scrolling vertically
   - Make folder cells smaller
- Remove previous/next page buttons, since there is no pagination now

## Resolutions

- Resolves #15